### PR TITLE
Cleanup restforce signature of unused input params.

### DIFF
--- a/src/RestforceClient.php
+++ b/src/RestforceClient.php
@@ -9,42 +9,6 @@ use stdClass;
 class RestforceClient
 {
     /**
-     * @var string
-     */
-    private $accessToken;
-    /**
-     * @var string
-     */
-    private $refreshToken;
-    /**
-     * @var string
-     */
-    private $host;
-    /**
-     * @var int
-     */
-    private $retryCount;
-    /**
-     * @var string
-     */
-    private $clientId;
-    /**
-     * @var string
-     */
-    private $clientSecret;
-    /**
-     * @var string
-     */
-    private $redirectURI;
-    /**
-     * @var TokenRefreshCallbackInterface
-     */
-    private $tokenRefreshObject;
-    /**
-     * @var string
-     */
-    private $resourceOwnerUrl;
-    /**
      * @var RestClientInterface
      */
     private $client;
@@ -53,37 +17,36 @@ class RestforceClient
      */
     private $instanceUrl;
     /**
+     * @var string
+     */
+    private $resourceOwnerUrl;
+    /**
+     * @var TokenRefreshCallbackInterface
+     */
+    private $tokenRefreshObject;
+    /**
      * @var array
      */
     private $headerOptions;
+    /**
+     * @var string
+     */
+    private $host;
 
     public function __construct(
         RestClientInterface $client,
-        string $accessToken,
-        string $refreshToken,
         string $instanceUrl,
-        string $clientId,
-        string $clientSecret,
-        string $redirectURI,
         string $resourceOwnerUrl,
         TokenRefreshCallbackInterface $tokenRefreshObject = null,
         array $headerOptions = [],
-        string $host = 'login.salesforce.com',
-        int $retryCount = 4
+        string $host = 'login.salesforce.com'
     ) {
-    
-        $this->clientId = $clientId;
-        $this->clientSecret = $clientSecret;
-        $this->redirectURI = $redirectURI;
-        $this->resourceOwnerUrl = $resourceOwnerUrl;
-        $this->tokenRefreshObject = $tokenRefreshObject;
-        $this->accessToken = $accessToken;
-        $this->refreshToken = $refreshToken;
-        $this->host = $host;
-        $this->retryCount = $retryCount;
         $this->client = $client;
         $this->instanceUrl = $instanceUrl;
+        $this->resourceOwnerUrl = $resourceOwnerUrl;
+        $this->tokenRefreshObject = $tokenRefreshObject;
         $this->headerOptions = $headerOptions;
+        $this->host = $host;
     }
 
     public function userInfo():stdClass

--- a/src/SalesforceOauth/SalesforceProviderRestClient.php
+++ b/src/SalesforceOauth/SalesforceProviderRestClient.php
@@ -39,7 +39,6 @@ class SalesforceProviderRestClient implements \Jmondi\Restforce\RestClient\RestC
         TokenRefreshCallbackInterface $tokenRefreshCallback = null,
         int $maxRetry = 2
     ) {
-    
         $this->client = $client;
         $this->salesforceProvider = $salesforceProvider;
         $this->accessToken = $accessToken;

--- a/tests/RestforceClientTest.php
+++ b/tests/RestforceClientTest.php
@@ -343,12 +343,7 @@ class RestforceClientTest extends \PHPUnit_Framework_TestCase
 
         $restforceClient = new RestforceClient(
             $client,
-            self::ACCESS_TOKEN,
-            self::REFRESH_TOKEN,
             self::INSTANCE_URI,
-            self::SALESFORCE_CLIENT_ID,
-            self::SALESFORCE_CLIENT_SECRET,
-            self::SALESFORCE_CALLBACK,
             self::RESOURCE_OWNER_ID,
             $tokenRefreshCallback
         );


### PR DESCRIPTION
By separating out the responsibility of the actual api requests and the token refresh on 401, I was able to clean up the signatures of the RestforceClient.php pretty heavily. 