### PR TITLE
Code cleanup

### DIFF
--- a/src/Oauth/AccessToken.php
+++ b/src/Oauth/AccessToken.php
@@ -32,19 +32,9 @@ class AccessToken implements AccessTokenInterface
         return $this->accessToken;
     }
 
-    public function setToken(string $accessToken)
-    {
-        $this->accessToken = $accessToken;
-    }
-
     public function getRefreshToken():string
     {
         return $this->refreshToken;
-    }
-
-    public function setRefreshToken(string $refreshToken)
-    {
-        $this->refreshToken = $refreshToken;
     }
 
     public function getInstanceUrl():string

--- a/src/RestforceClient.php
+++ b/src/RestforceClient.php
@@ -20,7 +20,7 @@ class RestforceClient
 
     const DEFAULT_HOST = 'login.salesforce.com';
     const DEFAULT_API_VERSION = 'v37.0';
-    const DEFAULT_RETRY_MAX_REQUESTS = 2;
+    const DEFAULT_MAX_RETRY_REQUESTS = 2;
     const DEFAULT_TOKEN_REFRESH_OBJECT = null;
 
     public static function with(
@@ -32,7 +32,7 @@ class RestforceClient
         string $resourceOwnerUrl,
         TokenRefreshInterface $tokenRefreshObject = self::DEFAULT_TOKEN_REFRESH_OBJECT,
         $apiVersion = self::DEFAULT_API_VERSION,
-        int $retryMaxRequests = self::DEFAULT_RETRY_MAX_REQUESTS
+        int $maxRetryRequests = self::DEFAULT_MAX_RETRY_REQUESTS
     ) {
     
         return new self(
@@ -41,7 +41,7 @@ class RestforceClient
             new AccessToken($accessToken, $refreshToken, $instanceUrl),
             $resourceOwnerUrl,
             $apiVersion,
-            $retryMaxRequests,
+            $maxRetryRequests,
             $tokenRefreshObject
         );
     }
@@ -57,7 +57,7 @@ class RestforceClient
         TokenRefreshInterface $tokenRefreshObject = self::DEFAULT_TOKEN_REFRESH_OBJECT,
         string $apiVersion = self::DEFAULT_API_VERSION,
         string $domain = self::DEFAULT_HOST,
-        int $retryMaxRequests = self::DEFAULT_RETRY_MAX_REQUESTS
+        int $maxRetryRequests = self::DEFAULT_MAX_RETRY_REQUESTS
     ) {
     
         $restClient = GuzzleRestClient::createClient();
@@ -75,7 +75,7 @@ class RestforceClient
             $resourceOwnerUrl,
             $apiVersion,
             $domain,
-            $retryMaxRequests,
+            $maxRetryRequests,
             $tokenRefreshObject
         );
     }
@@ -87,16 +87,16 @@ class RestforceClient
         string $resourceOwnerUrl,
         string $apiVersion,
         int $maxRetryRequests,
-        TokenRefreshInterface $tokenRefreshObject = null
+        TokenRefreshInterface $tokenRefreshObject = self::DEFAULT_TOKEN_REFRESH_OBJECT
     ) {
         $this->client = new SalesforceRestClient(
             $restClient,
             $salesforceProvider,
             $accessToken,
             $resourceOwnerUrl,
-            $tokenRefreshObject,
             $apiVersion,
-            $maxRetryRequests
+            $maxRetryRequests,
+            $tokenRefreshObject
         );
     }
 

--- a/tests/Oauth/StevenMaguireSalesforceProviderTest.php
+++ b/tests/Oauth/StevenMaguireSalesforceProviderTest.php
@@ -1,5 +1,5 @@
 <?php
-namespace Jmondi\Restforce\Test\Oauth;
+namespace Jmondi\Restforce\Tests\Oauth;
 
 use Jmondi\Restforce\Oauth\StevenMaguireSalesforceProvider;
 use League\OAuth2\Client\Token\AccessToken;

--- a/tests/RestClient/GuzzleRestClientTest.php
+++ b/tests/RestClient/GuzzleRestClientTest.php
@@ -1,5 +1,5 @@
 <?php
-namespace Jmondi\Restforce\Test\RestClient;
+namespace Jmondi\Restforce\Tests\RestClient;
 
 use Jmondi\Restforce\RestClient\GuzzleRestClient;
 use Mockery;

--- a/tests/RestClient/SalesforceRestClientTest.php
+++ b/tests/RestClient/SalesforceRestClientTest.php
@@ -1,5 +1,5 @@
 <?php
-namespace Jmondi\Restforce\Test\RestClient;
+namespace Jmondi\Restforce\Tests\RestClient;
 
 use Jmondi\Restforce\Oauth\AccessToken;
 use Jmondi\Restforce\Oauth\RetryAuthorizationTokenFailedException;
@@ -48,9 +48,9 @@ class SalesforceRestClientTest extends \PHPUnit_Framework_TestCase
             $provider,
             $accessToken,
             $resourceOwnerUrl,
-            $tokenRefreshCallback,
             $apiVersion,
-            $maxRetry
+            $maxRetry,
+            $tokenRefreshCallback
         );
 
         $this->expectException(RetryAuthorizationTokenFailedException::class);
@@ -102,9 +102,9 @@ class SalesforceRestClientTest extends \PHPUnit_Framework_TestCase
             $provider,
             $accessToken,
             $resourceOwnerUrl,
-            $tokenRefreshCallback,
             $apiVersion,
-            $maxRetry
+            $maxRetry,
+            $tokenRefreshCallback
         );
 
         $response = $salesforceProvider->request('GET', '/example/getExample');

--- a/tests/RestforceClientTest.php
+++ b/tests/RestforceClientTest.php
@@ -1,8 +1,9 @@
 <?php
-namespace Jmondi\Restforce;
+namespace Jmondi\Restforce\Tests;
 
 use Jmondi\Restforce\Oauth\SalesforceProviderInterface;
 use Jmondi\Restforce\RestClient\RestClientInterface;
+use Jmondi\Restforce\RestforceClient;
 use Mockery;
 use Psr\Http\Message\ResponseInterface;
 

--- a/tests/RestforceClientTest.php
+++ b/tests/RestforceClientTest.php
@@ -1,11 +1,8 @@
 <?php
 namespace Jmondi\Restforce;
 
-use GuzzleHttp\Psr7\Response;
-use Jmondi\Restforce\Oauth\AccessTokenInterface;
 use Jmondi\Restforce\Oauth\SalesforceProviderInterface;
 use Jmondi\Restforce\RestClient\RestClientInterface;
-use Jmondi\Restforce\TokenRefreshInterface;
 use Mockery;
 use Psr\Http\Message\ResponseInterface;
 
@@ -212,7 +209,8 @@ class RestforceClientTest extends \PHPUnit_Framework_TestCase
                 $this->assertEquals($endpoint, $e);
                 $this->assertEquals($options, $o);
                 return $response;
-            });
+            })
+            ->once();
 
         return RestforceClient::with(
             $restClient,


### PR DESCRIPTION
I added a `tests` branch, Jamie was looking over the package and said that basically the ‘with’ method is validating and we shouldnt need to do that crazyness with the ReturnUsing(function…

It is passing all tests, ultimately it doesnt matter which way, but `with` seems cleaner and I tested and verified that breaking something in the url structure on either end, with both `with` and `andReturnUsing` flag properly.